### PR TITLE
Replace task and log item temp ID with final ID when added

### DIFF
--- a/src/app/Home/DayTaskList.tsx
+++ b/src/app/Home/DayTaskList.tsx
@@ -44,7 +44,13 @@ const DayTaskList = () => {
         setTasks(context.previousTasks);
       }
     },
-    onSettled: () => {
+    onSuccess: (data, task) => {
+      if (data == null) return;
+      const taskFromResponse: ITask = data.data;
+
+      // When success, replace the task in Zustand state with the response data (id is different from backend)
+      editDayTask(task.id, taskFromResponse);
+
       void queryClient.invalidateQueries({ queryKey: ['tasks'] });
     },
   });
@@ -79,7 +85,7 @@ const DayTaskList = () => {
         'tasks',
       ]);
 
-      // Optimistically delete the task from Zustand state
+      // Optimistically edit the task from Zustand state
       editDayTask(taskID, task);
 
       return { previousTasks };
@@ -120,7 +126,7 @@ const DayTaskList = () => {
         setTasks(context.previousTasks);
       }
     },
-    onSettled: () => {
+    onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['tasks'] });
     },
   });

--- a/src/app/Home/HourActivityLogger.tsx
+++ b/src/app/Home/HourActivityLogger.tsx
@@ -29,7 +29,8 @@ export const HourActivityLogger: FC<IHourActivityLogger> = ({ date }) => {
 
   const { ref } = register('activityName');
 
-  const { setActivityLogs, addActivityLog } = useActivityLogStore();
+  const { setActivityLogs, addActivityLog, editActivityLog } =
+    useActivityLogStore();
 
   useEffect(() => {
     const timerInterval = setInterval(() => {
@@ -69,7 +70,12 @@ export const HourActivityLogger: FC<IHourActivityLogger> = ({ date }) => {
         setActivityLogs(context.previousActivityLogs);
       }
     },
-    onSettled: () => {
+    onSuccess: (data, activityLog) => {
+      if (data == null) return;
+      const activityLogFromResponse: IActivityLog = data.data;
+
+      // When success, replace the activity log in Zustand state with the response data (id is different from backend)
+      editActivityLog(activityLog.id, activityLogFromResponse);
       void queryClient.invalidateQueries({ queryKey: ['activity-logs'] });
     },
   });

--- a/src/app/Home/MonthTaskList.tsx
+++ b/src/app/Home/MonthTaskList.tsx
@@ -45,7 +45,12 @@ const MonthTaskList = () => {
         setTasks(context.previousTasks);
       }
     },
-    onSuccess: () => {
+    onSuccess: (data, task) => {
+      if (data == null) return;
+      const taskFromResponse: ITask = data.data;
+
+      // When success, replace the task in Zustand state with the response data (id is different from backend)
+      editMonthTask(task.id, taskFromResponse);
       void queryClient.invalidateQueries({ queryKey: ['tasks'] });
     },
   });

--- a/src/app/Home/WeekTaskList.tsx
+++ b/src/app/Home/WeekTaskList.tsx
@@ -45,7 +45,12 @@ const WeekTaskList = () => {
         setTasks(context.previousTasks);
       }
     },
-    onSettled: () => {
+    onSuccess: (data, task) => {
+      if (data == null) return;
+      const taskFromResponse: ITask = data.data;
+
+      // When success, replace the task in Zustand state with the response data (id is different from backend)
+      editWeekTask(task.id, taskFromResponse);
       void queryClient.invalidateQueries({ queryKey: ['tasks'] });
     },
   });

--- a/src/app/Home/YearTaskList.tsx
+++ b/src/app/Home/YearTaskList.tsx
@@ -45,7 +45,12 @@ const YearTaskList = () => {
         setTasks(context.previousTasks);
       }
     },
-    onSuccess: () => {
+    onSuccess: (data, task) => {
+      if (data == null) return;
+      const taskFromResponse: ITask = data.data;
+
+      // When success, replace the task in Zustand state with the response data (id is different from backend)
+      editYearTask(task.id, taskFromResponse);
       void queryClient.invalidateQueries({ queryKey: ['tasks'] });
     },
   });


### PR DESCRIPTION
To ensure after optimistically updating (with temporary ID), the item gets replaced (with its final ID) after it is processed by the backend